### PR TITLE
Adds support for gcc13 through -fcommon flag

### DIFF
--- a/tools/makefile
+++ b/tools/makefile
@@ -55,7 +55,7 @@ CC		= $($(OS)_CC)
 # CFLAGS
 AIX_CFLAGS		= -q64 -O3 -D_LARGE_FILES
 HPUX_CFLAGS		= -O3 -Wall
-LINUX_CFLAGS	= -g -Wall
+LINUX_CFLAGS	= -g -Wall -fcommon
 NCR_CFLAGS		= -g 
 SOLARIS_CFLAGS	= -O3 -Wall
 SOL86_CFLAGS	= -O3 


### PR DESCRIPTION
gcc 13 would give an error when compiling, this change makes it easy to compile even with gcc13