### PR TITLE
Query optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 tcpds
+etl_times.log
+experiment_run.csv

--- a/generate-data.sh
+++ b/generate-data.sh
@@ -3,9 +3,9 @@
 echo RESULTS:> etl_times.log
 echo ============= GENERATING DATA =============
 start_time=`date +%s`
-#rm tmp_data/*
+rm tmp_data/*
 cd tools || exit 1
-#./dsdgen -scale $1 -dir ../tmp_data 
+./dsdgen -scale $1 -dir ../tmp_data 
 cd ..
 end_time=`date +%s`
 echo GENERATING DATA: `expr $end_time - $start_time` s. >> etl_times.log
@@ -45,5 +45,3 @@ end_time=`date +%s`
 echo CREATING USEFUL TABLES: `expr $end_time - $start_time` s. >> etl_times.log
 
 echo ============= DATA LOADED =============
-
-#python time_queries.py

--- a/generate-data.sh
+++ b/generate-data.sh
@@ -3,11 +3,10 @@
 echo RESULTS:> etl_times.log
 echo ============= GENERATING DATA =============
 start_time=`date +%s`
-rm tmp_data/*
+#rm tmp_data/*
 cd tools || exit 1
-./dsdgen -scale $1 -dir ../tmp_data 
+#./dsdgen -scale $1 -dir ../tmp_data 
 cd ..
-sleep 2.1
 end_time=`date +%s`
 echo GENERATING DATA: `expr $end_time - $start_time` s. >> etl_times.log
 
@@ -22,14 +21,12 @@ docker cp ./tmp_data mssqldev:/usr/config/tmp_data
 echo ============= FORMATING DATA =============
 start_time=`date +%s`
 docker exec mssqldev find tmp_data -name *dat -exec bash -c 'sed -i 's/.$//' "$1"' - {} \; 
-sleep 1
 end_time=`date +%s`
 echo FORMATING DATA: `expr $end_time - $start_time` s. >> etl_times.log
 
 echo ============= INSERTING DATA INTO SQL SERVER =============
 start_time=`date +%s`
 docker exec mssqldev /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 2astazeY -d master -i upload-data.sql
-sleep 3
 end_time=`date +%s`
 echo INSERTING DATA: `expr $end_time - $start_time` s. >> etl_times.log
 
@@ -40,4 +37,13 @@ docker exec mssqldev /opt/mssql-tools/bin/sqlcmd -S localhost -U datawarehouse -
 end_time=`date +%s`
 echo CREATING INDEXES: `expr $end_time - $start_time` s. >> etl_times.log
 
+echo ============= CREATING USEFULL TABLES =============
+start_time=`date +%s`
+docker cp ./useful_tables.sql mssqldev:/usr/config
+docker exec mssqldev /opt/mssql-tools/bin/sqlcmd -S localhost -U datawarehouse -P 7ellowEl7akey -d master -i useful_tables.sql
+end_time=`date +%s`
+echo CREATING USEFUL TABLES: `expr $end_time - $start_time` s. >> etl_times.log
+
 echo ============= DATA LOADED =============
+
+#python time_queries.py

--- a/query_templates/query11.tpl
+++ b/query_templates/query11.tpl
@@ -39,64 +39,16 @@
                        ,{"t_s_secyear.customer_email_address",1});
  define _LIMIT=100;
 
- with year_total as (
- select c_customer_id customer_id
-       ,c_first_name customer_first_name
-       ,c_last_name customer_last_name
-       ,c_preferred_cust_flag customer_preferred_cust_flag
-       ,c_birth_country customer_birth_country
-       ,c_login customer_login
-       ,c_email_address customer_email_address
-       ,d_year dyear
-       ,sum(ss_ext_list_price-ss_ext_discount_amt) year_total
-       ,'s' sale_type
- from customer
-     ,store_sales
-     ,date_dim
- where c_customer_sk = ss_customer_sk
-   and ss_sold_date_sk = d_date_sk
- group by c_customer_id
-         ,c_first_name
-         ,c_last_name
-         ,c_preferred_cust_flag 
-         ,c_birth_country
-         ,c_login
-         ,c_email_address
-         ,d_year 
- union all
- select c_customer_id customer_id
-       ,c_first_name customer_first_name
-       ,c_last_name customer_last_name
-       ,c_preferred_cust_flag customer_preferred_cust_flag
-       ,c_birth_country customer_birth_country
-       ,c_login customer_login
-       ,c_email_address customer_email_address
-       ,d_year dyear
-       ,sum(ws_ext_list_price-ws_ext_discount_amt) year_total
-       ,'w' sale_type
- from customer
-     ,web_sales
-     ,date_dim
- where c_customer_sk = ws_bill_customer_sk
-   and ws_sold_date_sk = d_date_sk
- group by c_customer_id
-         ,c_first_name
-         ,c_last_name
-         ,c_preferred_cust_flag 
-         ,c_birth_country
-         ,c_login
-         ,c_email_address
-         ,d_year
-         )
+ 
  [_LIMITA] select [_LIMITB] 
                   t_s_secyear.customer_id
                  ,t_s_secyear.customer_first_name
                  ,t_s_secyear.customer_last_name
                  ,[SELECTONE]
- from year_total t_s_firstyear
-     ,year_total t_s_secyear
-     ,year_total t_w_firstyear
-     ,year_total t_w_secyear
+ from query_6_year_total t_s_firstyear
+     ,query_6_year_total t_s_secyear
+     ,query_6_year_total t_w_firstyear
+     ,query_6_year_total t_w_secyear
  where t_s_secyear.customer_id = t_s_firstyear.customer_id
          and t_s_firstyear.customer_id = t_w_secyear.customer_id
          and t_s_firstyear.customer_id = t_w_firstyear.customer_id

--- a/query_templates/query14.tpl
+++ b/query_templates/query14.tpl
@@ -36,45 +36,8 @@
  define DAY = random(1,28,uniform);
  define _LIMIT=100; 
 
-with  foo as (
-  select iss.i_brand_id brand_id
-     ,iss.i_class_id class_id
-     ,iss.i_category_id category_id
- from store_sales
-     ,item iss
-     ,date_dim d1
- where ss_item_sk = iss.i_item_sk
-   and ss_sold_date_sk = d1.d_date_sk
-   and d1.d_year between [YEAR] AND [YEAR] + 2
- intersect 
- select ics.i_brand_id
-     ,ics.i_class_id
-     ,ics.i_category_id
- from catalog_sales
-     ,item ics
-     ,date_dim d2
- where cs_item_sk = ics.i_item_sk
-   and cs_sold_date_sk = d2.d_date_sk
-   and d2.d_year between [YEAR] AND [YEAR] + 2
- intersect
- select iws.i_brand_id
-     ,iws.i_class_id
-     ,iws.i_category_id
- from web_sales
-     ,item iws
-     ,date_dim d3
- where ws_item_sk = iws.i_item_sk
-   and ws_sold_date_sk = d3.d_date_sk
-   and d3.d_year between [YEAR] AND [YEAR] + 2)
-,cross_items as
- (select i_item_sk ss_item_sk
- from item, foo
- where i_brand_id = brand_id
-      and i_class_id = class_id
-      and i_category_id = category_id
-),
- avg_sales as
- (select avg(quantity*list_price) average_sales
+select avg(quantity*list_price) average_sales
+into #avg_sales
   from (select ss_quantity quantity
              ,ss_list_price list_price
        from store_sales
@@ -94,58 +57,15 @@ with  foo as (
        from web_sales
            ,date_dim
        where ws_sold_date_sk = d_date_sk
-         and d_year between [YEAR] and [YEAR] + 2) x)
- [_LIMITA] select [_LIMITB] channel, i_brand_id,i_class_id,i_category_id,sum(sales), sum(number_sales)
- from(
-       select 'store' channel, i_brand_id,i_class_id
-             ,i_category_id,sum(ss_quantity*ss_list_price) sales
-             , count(*) number_sales
-       from store_sales
-           ,item
-           ,date_dim
-       where ss_item_sk in (select ss_item_sk from cross_items)
-         and ss_item_sk = i_item_sk
-         and ss_sold_date_sk = d_date_sk
-         and d_year = [YEAR]+2 
-         and d_moy = 11
-       group by i_brand_id,i_class_id,i_category_id
-       having sum(ss_quantity*ss_list_price) > (select average_sales from avg_sales)
-       union all
-       select 'catalog' channel, i_brand_id,i_class_id,i_category_id, sum(cs_quantity*cs_list_price) sales, count(*) number_sales
-       from catalog_sales
-           ,item
-           ,date_dim
-       where cs_item_sk in (select ss_item_sk from cross_items)
-         and cs_item_sk = i_item_sk
-         and cs_sold_date_sk = d_date_sk
-         and d_year = [YEAR]+2 
-         and d_moy = 11
-       group by i_brand_id,i_class_id,i_category_id
-       having sum(cs_quantity*cs_list_price) > (select average_sales from avg_sales)
-       union all
-       select 'web' channel, i_brand_id,i_class_id,i_category_id, sum(ws_quantity*ws_list_price) sales , count(*) number_sales
-       from web_sales
-           ,item
-           ,date_dim
-       where ws_item_sk in (select ss_item_sk from cross_items)
-         and ws_item_sk = i_item_sk
-         and ws_sold_date_sk = d_date_sk
-         and d_year = [YEAR]+2
-         and d_moy = 11
-       group by i_brand_id,i_class_id,i_category_id
-       having sum(ws_quantity*ws_list_price) > (select average_sales from avg_sales)
- ) y
- group by rollup (channel, i_brand_id,i_class_id,i_category_id)
- order by channel,i_brand_id,i_class_id,i_category_id
- [_LIMITC];
- 
- with  cross_items as
- (select i_item_sk ss_item_sk
+         and d_year between [YEAR] and [YEAR] + 2) x;
+
+select i_item_sk ss_item_sk
+into #cross_items
  from item,
  (select iss.i_brand_id brand_id
      ,iss.i_class_id class_id
      ,iss.i_category_id category_id
- from store_sales
+ from store_sales WITH (FORCESCAN)
      ,item iss
      ,date_dim d1
  where ss_item_sk = iss.i_item_sk
@@ -155,7 +75,7 @@ with  foo as (
  select ics.i_brand_id
      ,ics.i_class_id
      ,ics.i_category_id
- from catalog_sales
+ from catalog_sales WITH (FORCESCAN)
      ,item ics
      ,date_dim d2
  where cs_item_sk = ics.i_item_sk
@@ -165,7 +85,7 @@ with  foo as (
  select iws.i_brand_id
      ,iws.i_class_id
      ,iws.i_category_id
- from web_sales
+ from web_sales WITH (FORCESCAN)
      ,item iws
      ,date_dim d3
  where ws_item_sk = iws.i_item_sk
@@ -173,30 +93,54 @@ with  foo as (
    and d3.d_year between [YEAR] AND [YEAR] + 2) x
  where i_brand_id = brand_id
       and i_class_id = class_id
-      and i_category_id = category_id
-),
- avg_sales as
-(select avg(quantity*list_price) average_sales
-  from (select ss_quantity quantity
-             ,ss_list_price list_price
+      and i_category_id = category_id;
+
+
+ [_LIMITA] select [_LIMITB] channel, i_brand_id,i_class_id,i_category_id,sum(sales), sum(number_sales)
+ from(
+       select 'store' channel, i_brand_id,i_class_id
+             ,i_category_id,sum(ss_quantity*ss_list_price) sales
+             , count(*) number_sales
        from store_sales
+           ,item
            ,date_dim
-       where ss_sold_date_sk = d_date_sk
-         and d_year between [YEAR] and [YEAR] + 2
+       where ss_item_sk in (select ss_item_sk from #cross_items)
+         and ss_item_sk = i_item_sk
+         and ss_sold_date_sk = d_date_sk
+         and d_year = [YEAR]+2 
+         and d_moy = 11
+       group by i_brand_id,i_class_id,i_category_id
+       having sum(ss_quantity*ss_list_price) > (select average_sales from #avg_sales)
        union all
-       select cs_quantity quantity
-             ,cs_list_price list_price
+       select 'catalog' channel, i_brand_id,i_class_id,i_category_id, sum(cs_quantity*cs_list_price) sales, count(*) number_sales
        from catalog_sales
+           ,item
            ,date_dim
-       where cs_sold_date_sk = d_date_sk
-         and d_year between [YEAR] and [YEAR] + 2
+       where cs_item_sk in (select ss_item_sk from #cross_items)
+         and cs_item_sk = i_item_sk
+         and cs_sold_date_sk = d_date_sk
+         and d_year = [YEAR]+2 
+         and d_moy = 11
+       group by i_brand_id,i_class_id,i_category_id
+       having sum(cs_quantity*cs_list_price) > (select average_sales from #avg_sales)
        union all
-       select ws_quantity quantity
-             ,ws_list_price list_price
+       select 'web' channel, i_brand_id,i_class_id,i_category_id, sum(ws_quantity*ws_list_price) sales , count(*) number_sales
        from web_sales
+           ,item
            ,date_dim
-       where ws_sold_date_sk = d_date_sk
-         and d_year between [YEAR] and [YEAR] + 2) x)
+       where ws_item_sk in (select ss_item_sk from #cross_items)
+         and ws_item_sk = i_item_sk
+         and ws_sold_date_sk = d_date_sk
+         and d_year = [YEAR]+2
+         and d_moy = 11
+       group by i_brand_id,i_class_id,i_category_id
+       having sum(ws_quantity*ws_list_price) > (select average_sales from #avg_sales)
+ ) y
+ group by rollup (channel, i_brand_id,i_class_id,i_category_id)
+ order by channel,i_brand_id,i_class_id,i_category_id
+ [_LIMITC];
+ 
+ 
  [_LIMITA] select [_LIMITB] this_year.channel ty_channel
                            ,this_year.i_brand_id ty_brand
                            ,this_year.i_class_id ty_class
@@ -215,7 +159,7 @@ with  foo as (
  from store_sales 
      ,item
      ,date_dim
- where ss_item_sk in (select ss_item_sk from cross_items)
+ where ss_item_sk in (select ss_item_sk from #cross_items)
    and ss_item_sk = i_item_sk
    and ss_sold_date_sk = d_date_sk
    and d_week_seq = (select d_week_seq
@@ -224,13 +168,13 @@ with  foo as (
                        and d_moy = 12
                        and d_dom = [DAY])
  group by i_brand_id,i_class_id,i_category_id
- having sum(ss_quantity*ss_list_price) > (select average_sales from avg_sales)) this_year,
+ having sum(ss_quantity*ss_list_price) > (select average_sales from #avg_sales)) this_year,
  (select 'store' channel, i_brand_id,i_class_id
         ,i_category_id, sum(ss_quantity*ss_list_price) sales, count(*) number_sales
  from store_sales
      ,item
      ,date_dim
- where ss_item_sk in (select ss_item_sk from cross_items)
+ where ss_item_sk in (select ss_item_sk from #cross_items)
    and ss_item_sk = i_item_sk
    and ss_sold_date_sk = d_date_sk
    and d_week_seq = (select d_week_seq
@@ -239,7 +183,7 @@ with  foo as (
                        and d_moy = 12
                        and d_dom = [DAY])
  group by i_brand_id,i_class_id,i_category_id
- having sum(ss_quantity*ss_list_price) > (select average_sales from avg_sales)) last_year
+ having sum(ss_quantity*ss_list_price) > (select average_sales from #avg_sales)) last_year
  where this_year.i_brand_id= last_year.i_brand_id
    and this_year.i_class_id = last_year.i_class_id
    and this_year.i_category_id = last_year.i_category_id

--- a/query_templates/query2.tpl
+++ b/query_templates/query2.tpl
@@ -34,27 +34,7 @@
 -- 
  define YEAR=random(1998,2001,uniform);
   
- with wscs as
- (select ws_sold_date_sk sold_date_sk
-              ,ws_ext_sales_price sales_price
-        from web_sales 
-        union all
-        select cs_sold_date_sk sold_date_sk
-              ,cs_ext_sales_price sales_price
-        from catalog_sales),
- wswscs as 
- (select d_week_seq,
-        sum(case when (d_day_name='Sunday') then sales_price else null end) sun_sales,
-        sum(case when (d_day_name='Monday') then sales_price else null end) mon_sales,
-        sum(case when (d_day_name='Tuesday') then sales_price else  null end) tue_sales,
-        sum(case when (d_day_name='Wednesday') then sales_price else null end) wed_sales,
-        sum(case when (d_day_name='Thursday') then sales_price else null end) thu_sales,
-        sum(case when (d_day_name='Friday') then sales_price else null end) fri_sales,
-        sum(case when (d_day_name='Saturday') then sales_price else null end) sat_sales
- from wscs
-     ,date_dim
- where d_date_sk = sold_date_sk
- group by d_week_seq)
+ 
  select d_week_seq1
        ,round(sun_sales1/sun_sales2,2)
        ,round(mon_sales1/mon_sales2,2)
@@ -64,7 +44,7 @@
        ,round(fri_sales1/fri_sales2,2)
        ,round(sat_sales1/sat_sales2,2)
  from
- (select wswscs.d_week_seq d_week_seq1
+ (select query_2_wswscs.d_week_seq d_week_seq1
         ,sun_sales sun_sales1
         ,mon_sales mon_sales1
         ,tue_sales tue_sales1
@@ -72,10 +52,10 @@
         ,thu_sales thu_sales1
         ,fri_sales fri_sales1
         ,sat_sales sat_sales1
-  from wswscs,date_dim 
-  where date_dim.d_week_seq = wswscs.d_week_seq and
+  from query_2_wswscs,date_dim 
+  where date_dim.d_week_seq = query_2_wswscs.d_week_seq and
         d_year = [YEAR]) y,
- (select wswscs.d_week_seq d_week_seq2
+ (select query_2_wswscs.d_week_seq d_week_seq2
         ,sun_sales sun_sales2
         ,mon_sales mon_sales2
         ,tue_sales tue_sales2
@@ -83,9 +63,9 @@
         ,thu_sales thu_sales2
         ,fri_sales fri_sales2
         ,sat_sales sat_sales2
-  from wswscs
+  from query_2_wswscs
       ,date_dim 
-  where date_dim.d_week_seq = wswscs.d_week_seq and
+  where date_dim.d_week_seq = query_2_wswscs.d_week_seq and
         d_year = [YEAR]+1) z
  where d_week_seq1=d_week_seq2-53
  order by d_week_seq1;

--- a/query_templates/query31.tpl
+++ b/query_templates/query31.tpl
@@ -36,18 +36,6 @@
  define AGG= text({"ss1.ca_county",1},{"ss1.d_year",1},{"web_q1_q2_increase",1},{"store_q1_q2_increase",1},{"web_q2_q3_increase",1},{"store_q2_q3_increase",1}); 
 
 
- with ss as
- (select ca_county,d_qoy, d_year,sum(ss_ext_sales_price) as store_sales
- from store_sales,date_dim,customer_address
- where ss_sold_date_sk = d_date_sk
-  and ss_addr_sk=ca_address_sk
- group by ca_county,d_qoy, d_year),
- ws as
- (select ca_county,d_qoy, d_year,sum(ws_ext_sales_price) as web_sales
- from web_sales,date_dim,customer_address
- where ws_sold_date_sk = d_date_sk
-  and ws_bill_addr_sk=ca_address_sk
- group by ca_county,d_qoy, d_year)
  select 
         ss1.ca_county
        ,ss1.d_year
@@ -56,12 +44,12 @@
        ,ws3.web_sales/ws2.web_sales web_q2_q3_increase
        ,ss3.store_sales/ss2.store_sales store_q2_q3_increase
  from
-        ss ss1
-       ,ss ss2
-       ,ss ss3
-       ,ws ws1
-       ,ws ws2
-       ,ws ws3
+        query_31_ss ss1
+       ,query_31_ss ss2
+       ,query_31_ss ss3
+       ,query_31_ws ws1
+       ,query_31_ws ws2
+       ,query_31_ws ws3
  where
     ss1.d_qoy = 1
     and ss1.d_year = [YEAR]

--- a/query_templates/query4.tpl
+++ b/query_templates/query4.tpl
@@ -117,12 +117,12 @@ union all
                  ,t_s_secyear.customer_first_name
                  ,t_s_secyear.customer_last_name
                  ,[SELECTONE]
- from (select * from year_total where sale_type='s' and dyear = 2000 ) t_s_firstyear 
-    inner join (select * from year_total where sale_type='s' and dyear = 2000+1) t_s_secyear on t_s_secyear.customer_id = t_s_firstyear.customer_id 
-    inner join (select * from year_total where sale_type='c' and dyear = 2000) t_c_firstyear on t_s_firstyear.customer_id = t_c_firstyear.customer_id 
-    inner join (select * from year_total where sale_type='c' and dyear = 2000+1) t_c_secyear on t_s_firstyear.customer_id = t_c_secyear.customer_id 
-    inner join (select * from year_total where sale_type='w' and dyear = 2000) t_w_firstyear on t_s_firstyear.customer_id = t_w_firstyear.customer_id
-    inner join (select * from year_total where sale_type='w' and dyear = 2000+1 ) t_w_secyear on t_s_firstyear.customer_id = t_w_secyear.customer_id
+ from (select * from year_total where sale_type='s' and dyear = [YEAR] ) t_s_firstyear 
+    inner join (select * from year_total where sale_type='s' and dyear = [YEAR]+1) t_s_secyear on t_s_secyear.customer_id = t_s_firstyear.customer_id 
+    inner join (select * from year_total where sale_type='c' and dyear = [YEAR]) t_c_firstyear on t_s_firstyear.customer_id = t_c_firstyear.customer_id 
+    inner join (select * from year_total where sale_type='c' and dyear = [YEAR]+1) t_c_secyear on t_s_firstyear.customer_id = t_c_secyear.customer_id 
+    inner join (select * from year_total where sale_type='w' and dyear = [YEAR]) t_w_firstyear on t_s_firstyear.customer_id = t_w_firstyear.customer_id
+    inner join (select * from year_total where sale_type='w' and dyear = [YEAR]+1 ) t_w_secyear on t_s_firstyear.customer_id = t_w_secyear.customer_id
  where 
   case when t_c_firstyear.year_total > 0 then t_c_secyear.year_total / t_c_firstyear.year_total else null end
            > case when t_s_firstyear.year_total > 0 then t_s_secyear.year_total / t_s_firstyear.year_total else null end

--- a/query_templates/query4.tpl
+++ b/query_templates/query4.tpl
@@ -117,33 +117,14 @@ union all
                  ,t_s_secyear.customer_first_name
                  ,t_s_secyear.customer_last_name
                  ,[SELECTONE]
- from year_total t_s_firstyear
-     ,year_total t_s_secyear
-     ,year_total t_c_firstyear
-     ,year_total t_c_secyear
-     ,year_total t_w_firstyear
-     ,year_total t_w_secyear
- where t_s_secyear.customer_id = t_s_firstyear.customer_id
-   and t_s_firstyear.customer_id = t_c_secyear.customer_id
-   and t_s_firstyear.customer_id = t_c_firstyear.customer_id
-   and t_s_firstyear.customer_id = t_w_firstyear.customer_id
-   and t_s_firstyear.customer_id = t_w_secyear.customer_id
-   and t_s_firstyear.sale_type = 's'
-   and t_c_firstyear.sale_type = 'c'
-   and t_w_firstyear.sale_type = 'w'
-   and t_s_secyear.sale_type = 's'
-   and t_c_secyear.sale_type = 'c'
-   and t_w_secyear.sale_type = 'w'
-   and t_s_firstyear.dyear =  [YEAR]
-   and t_s_secyear.dyear = [YEAR]+1
-   and t_c_firstyear.dyear =  [YEAR]
-   and t_c_secyear.dyear =  [YEAR]+1
-   and t_w_firstyear.dyear = [YEAR]
-   and t_w_secyear.dyear = [YEAR]+1
-   and t_s_firstyear.year_total > 0
-   and t_c_firstyear.year_total > 0
-   and t_w_firstyear.year_total > 0
-   and case when t_c_firstyear.year_total > 0 then t_c_secyear.year_total / t_c_firstyear.year_total else null end
+ from (select * from year_total where sale_type='s' and dyear = 2000 ) t_s_firstyear 
+    inner join (select * from year_total where sale_type='s' and dyear = 2000+1) t_s_secyear on t_s_secyear.customer_id = t_s_firstyear.customer_id 
+    inner join (select * from year_total where sale_type='c' and dyear = 2000) t_c_firstyear on t_s_firstyear.customer_id = t_c_firstyear.customer_id 
+    inner join (select * from year_total where sale_type='c' and dyear = 2000+1) t_c_secyear on t_s_firstyear.customer_id = t_c_secyear.customer_id 
+    inner join (select * from year_total where sale_type='w' and dyear = 2000) t_w_firstyear on t_s_firstyear.customer_id = t_w_firstyear.customer_id
+    inner join (select * from year_total where sale_type='w' and dyear = 2000+1 ) t_w_secyear on t_s_firstyear.customer_id = t_w_secyear.customer_id
+ where 
+  case when t_c_firstyear.year_total > 0 then t_c_secyear.year_total / t_c_firstyear.year_total else null end
            > case when t_s_firstyear.year_total > 0 then t_s_secyear.year_total / t_s_firstyear.year_total else null end
    and case when t_c_firstyear.year_total > 0 then t_c_secyear.year_total / t_c_firstyear.year_total else null end
            > case when t_w_firstyear.year_total > 0 then t_w_secyear.year_total / t_w_firstyear.year_total else null end

--- a/query_templates/query47.tpl
+++ b/query_templates/query47.tpl
@@ -54,12 +54,47 @@
  from item, store_sales, date_dim, store
  where ss_item_sk = i_item_sk and
        ss_sold_date_sk = d_date_sk and
-       ss_store_sk = s_store_sk and
-       (
-         d_year = [YEAR] or
-         ( d_year = [YEAR]-1 and d_moy =12) or
-         ( d_year = [YEAR]+1 and d_moy =1)
-       )
+       ss_store_sk = s_store_sk and d_year = [YEAR]
+ group by i_category, i_brand,
+          s_store_name, s_company_name,
+          d_year, d_moy
+UNION
+ select i_category, i_brand,
+        s_store_name, s_company_name,
+        d_year, d_moy,
+        sum(ss_sales_price) sum_sales,
+        avg(sum(ss_sales_price)) over
+          (partition by i_category, i_brand,
+                     s_store_name, s_company_name, d_year)
+          avg_monthly_sales,
+        rank() over
+          (partition by i_category, i_brand,
+                     s_store_name, s_company_name
+           order by d_year, d_moy) rn
+ from item, store_sales, date_dim, store
+ where ss_item_sk = i_item_sk and
+       ss_sold_date_sk = d_date_sk and
+       ss_store_sk = s_store_sk and d_year = [YEAR]-1 and d_moy =12
+ group by i_category, i_brand,
+          s_store_name, s_company_name,
+          d_year, d_moy
+UNION
+ select i_category, i_brand,
+        s_store_name, s_company_name,
+        d_year, d_moy,
+        sum(ss_sales_price) sum_sales,
+        avg(sum(ss_sales_price)) over
+          (partition by i_category, i_brand,
+                     s_store_name, s_company_name, d_year)
+          avg_monthly_sales,
+        rank() over
+          (partition by i_category, i_brand,
+                     s_store_name, s_company_name
+           order by d_year, d_moy) rn
+ from item, store_sales, date_dim, store
+ where ss_item_sk = i_item_sk and
+       ss_sold_date_sk = d_date_sk and
+       ss_store_sk = s_store_sk and d_year = [YEAR]+1 and d_moy =1
  group by i_category, i_brand,
           s_store_name, s_company_name,
           d_year, d_moy),

--- a/query_templates/query57.tpl
+++ b/query_templates/query57.tpl
@@ -52,7 +52,7 @@
           (partition by i_category, i_brand,
                      cc_name
            order by d_year, d_moy) rn
- from item, catalog_sales, date_dim, call_center
+ from item, catalog_sales WITH (FORCESCAN), date_dim, call_center
  where cs_item_sk = i_item_sk and
        cs_sold_date_sk = d_date_sk and
        cc_call_center_sk= cs_call_center_sk and

--- a/query_templates/query59.tpl
+++ b/query_templates/query59.tpl
@@ -35,41 +35,28 @@
  define DMS = random(1176,1212,uniform);
  define _LIMIT=100;
  
- with wss as 
- (select d_week_seq,
-        ss_store_sk,
-        sum(case when (d_day_name='Sunday') then ss_sales_price else null end) sun_sales,
-        sum(case when (d_day_name='Monday') then ss_sales_price else null end) mon_sales,
-        sum(case when (d_day_name='Tuesday') then ss_sales_price else  null end) tue_sales,
-        sum(case when (d_day_name='Wednesday') then ss_sales_price else null end) wed_sales,
-        sum(case when (d_day_name='Thursday') then ss_sales_price else null end) thu_sales,
-        sum(case when (d_day_name='Friday') then ss_sales_price else null end) fri_sales,
-        sum(case when (d_day_name='Saturday') then ss_sales_price else null end) sat_sales
- from store_sales,date_dim
- where d_date_sk = ss_sold_date_sk
- group by d_week_seq,ss_store_sk
- )
+ 
  [_LIMITA] select [_LIMITB] s_store_name1,s_store_id1,d_week_seq1
        ,sun_sales1/sun_sales2,mon_sales1/mon_sales2
        ,tue_sales1/tue_sales2,wed_sales1/wed_sales2,thu_sales1/thu_sales2
        ,fri_sales1/fri_sales2,sat_sales1/sat_sales2
  from
- (select s_store_name s_store_name1,wss.d_week_seq d_week_seq1
+ (select s_store_name s_store_name1,query_59_wss.d_week_seq d_week_seq1
         ,s_store_id s_store_id1,sun_sales sun_sales1
         ,mon_sales mon_sales1,tue_sales tue_sales1
         ,wed_sales wed_sales1,thu_sales thu_sales1
         ,fri_sales fri_sales1,sat_sales sat_sales1
-  from wss,store,date_dim d
-  where d.d_week_seq = wss.d_week_seq and
+  from query_59_wss,store,date_dim d
+  where d.d_week_seq = query_59_wss.d_week_seq and
         ss_store_sk = s_store_sk and 
         d_month_seq between [DMS] and [DMS] + 11) y,
- (select s_store_name s_store_name2,wss.d_week_seq d_week_seq2
+ (select s_store_name s_store_name2,query_59_wss.d_week_seq d_week_seq2
         ,s_store_id s_store_id2,sun_sales sun_sales2
         ,mon_sales mon_sales2,tue_sales tue_sales2
         ,wed_sales wed_sales2,thu_sales thu_sales2
         ,fri_sales fri_sales2,sat_sales sat_sales2
-  from wss,store,date_dim d
-  where d.d_week_seq = wss.d_week_seq and
+  from query_59_wss,store,date_dim d
+  where d.d_week_seq = query_59_wss.d_week_seq and
         ss_store_sk = s_store_sk and 
         d_month_seq between [DMS]+ 12 and [DMS] + 23) x
  where s_store_id1=s_store_id2

--- a/query_templates/query59.tpl
+++ b/query_templates/query59.tpl
@@ -46,19 +46,19 @@
         ,mon_sales mon_sales1,tue_sales tue_sales1
         ,wed_sales wed_sales1,thu_sales thu_sales1
         ,fri_sales fri_sales1,sat_sales sat_sales1
-  from query_59_wss,store,date_dim d
-  where d.d_week_seq = query_59_wss.d_week_seq and
-        ss_store_sk = s_store_sk and 
-        d_month_seq between [DMS] and [DMS] + 11) y,
+  from query_59_wss
+  inner join store on ss_store_sk = s_store_sk
+  inner join date_dim d on d.d_week_seq = query_59_wss.d_week_seq
+  where d_month_seq between [DMS] and [DMS] + 11) y,
  (select s_store_name s_store_name2,query_59_wss.d_week_seq d_week_seq2
         ,s_store_id s_store_id2,sun_sales sun_sales2
         ,mon_sales mon_sales2,tue_sales tue_sales2
         ,wed_sales wed_sales2,thu_sales thu_sales2
         ,fri_sales fri_sales2,sat_sales sat_sales2
-  from query_59_wss,store,date_dim d
-  where d.d_week_seq = query_59_wss.d_week_seq and
-        ss_store_sk = s_store_sk and 
-        d_month_seq between [DMS]+ 12 and [DMS] + 23) x
+  from query_59_wss
+  inner join store on ss_store_sk = s_store_sk
+  inner join date_dim d on d.d_week_seq = query_59_wss.d_week_seq
+  where  d_month_seq between [DMS]+ 12 and [DMS] + 23) x
  where s_store_id1=s_store_id2
    and d_week_seq1=d_week_seq2-52
  order by s_store_name1,s_store_id1,d_week_seq1

--- a/query_templates/query7.tpl
+++ b/query_templates/query7.tpl
@@ -43,12 +43,12 @@
         avg(ss_list_price) agg2,
         avg(ss_coupon_amt) agg3,
         avg(ss_sales_price) agg4 
- from store_sales, customer_demographics, date_dim, item, promotion
- where ss_sold_date_sk = d_date_sk and
-       ss_item_sk = i_item_sk and
-       ss_cdemo_sk = cd_demo_sk and
-       ss_promo_sk = p_promo_sk and
-       cd_gender = '[GEN]' and 
+ from store_sales WITH (FORCESCAN) 
+ inner join customer_demographics on ss_cdemo_sk = cd_demo_sk
+ inner join date_dim on ss_sold_date_sk = d_date_sk
+ inner join item on ss_item_sk = i_item_sk
+ inner join promotion on ss_promo_sk = p_promo_sk
+ where cd_gender = '[GEN]' and 
        cd_marital_status = '[MS]' and
        cd_education_status = '[ES]' and
        (p_channel_email = 'N' or p_channel_event = 'N') and

--- a/query_templates/query78.tpl
+++ b/query_templates/query78.tpl
@@ -37,42 +37,6 @@ define SELECTONE=text({"ss_sold_year",1},{"ss_item_sk",1},{"ss_customer_sk",1},{
 
 define _LIMIT = 100;
 
-with ws as
-  (select d_year AS ws_sold_year, ws_item_sk,
-    ws_bill_customer_sk ws_customer_sk,
-    sum(ws_quantity) ws_qty,
-    sum(ws_wholesale_cost) ws_wc,
-    sum(ws_sales_price) ws_sp
-   from web_sales
-   left join web_returns on wr_order_number=ws_order_number and ws_item_sk=wr_item_sk
-   join date_dim on ws_sold_date_sk = d_date_sk
-   where wr_order_number is null
-   group by d_year, ws_item_sk, ws_bill_customer_sk
-   ),
-cs as
-  (select d_year AS cs_sold_year, cs_item_sk,
-    cs_bill_customer_sk cs_customer_sk,
-    sum(cs_quantity) cs_qty,
-    sum(cs_wholesale_cost) cs_wc,
-    sum(cs_sales_price) cs_sp
-   from catalog_sales
-   left join catalog_returns on cr_order_number=cs_order_number and cs_item_sk=cr_item_sk
-   join date_dim on cs_sold_date_sk = d_date_sk
-   where cr_order_number is null
-   group by d_year, cs_item_sk, cs_bill_customer_sk
-   ),
-ss as
-  (select d_year AS ss_sold_year, ss_item_sk,
-    ss_customer_sk,
-    sum(ss_quantity) ss_qty,
-    sum(ss_wholesale_cost) ss_wc,
-    sum(ss_sales_price) ss_sp
-   from store_sales
-   left join store_returns on sr_ticket_number=ss_ticket_number and ss_item_sk=sr_item_sk
-   join date_dim on ss_sold_date_sk = d_date_sk
-   where sr_ticket_number is null
-   group by d_year, ss_item_sk, ss_customer_sk
-   )
 [_LIMITA] select [_LIMITB]
 [SELECTONE],
 round(ss_qty/(coalesce(ws_qty,0)+coalesce(cs_qty,0)),2) ratio,
@@ -80,9 +44,9 @@ ss_qty store_qty, ss_wc store_wholesale_cost, ss_sp store_sales_price,
 coalesce(ws_qty,0)+coalesce(cs_qty,0) other_chan_qty,
 coalesce(ws_wc,0)+coalesce(cs_wc,0) other_chan_wholesale_cost,
 coalesce(ws_sp,0)+coalesce(cs_sp,0) other_chan_sales_price
-from ss
-left join ws on (ws_sold_year=ss_sold_year and ws_item_sk=ss_item_sk and ws_customer_sk=ss_customer_sk)
-left join cs on (cs_sold_year=ss_sold_year and cs_item_sk=ss_item_sk and cs_customer_sk=ss_customer_sk)
+from query_78_ss
+left join query_78_ws on (ws_sold_year=ss_sold_year and ws_item_sk=ss_item_sk and ws_customer_sk=ss_customer_sk)
+left join query_78_cs on (cs_sold_year=ss_sold_year and cs_item_sk=ss_item_sk and cs_customer_sk=ss_customer_sk)
 where (coalesce(ws_qty,0)>0 or coalesce(cs_qty, 0)>0) and ss_sold_year=[YEAR]
 order by 
   [SELECTONE],

--- a/useful_tables.sql
+++ b/useful_tables.sql
@@ -73,3 +73,54 @@ select d_year AS ss_sold_year, ss_item_sk,
    join date_dim on ss_sold_date_sk = d_date_sk
    where sr_ticket_number is null
    group by d_year, ss_item_sk, ss_customer_sk;
+
+-- query 11 
+with year_total as (
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum(ss_ext_list_price-ss_ext_discount_amt) year_total
+       ,'s' sale_type
+ from customer
+     ,store_sales
+     ,date_dim
+ where c_customer_sk = ss_customer_sk
+   and ss_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag 
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year 
+ union all
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum(ws_ext_list_price-ws_ext_discount_amt) year_total
+       ,'w' sale_type
+ from customer
+     ,web_sales
+     ,date_dim
+ where c_customer_sk = ws_bill_customer_sk
+   and ws_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag 
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year
+         ) select * into query_6_year_total from year_total;

--- a/useful_tables.sql
+++ b/useful_tables.sql
@@ -22,3 +22,54 @@ with wscs as
  group by d_week_seq)
  select *
  into query_2_wswscs from wswscs;
+
+-- Generate a table to speed up query number 59
+
+ select d_week_seq,
+        ss_store_sk,
+        sum(case when (d_day_name='Sunday') then ss_sales_price else null end) sun_sales,
+        sum(case when (d_day_name='Monday') then ss_sales_price else null end) mon_sales,
+        sum(case when (d_day_name='Tuesday') then ss_sales_price else  null end) tue_sales,
+        sum(case when (d_day_name='Wednesday') then ss_sales_price else null end) wed_sales,
+        sum(case when (d_day_name='Thursday') then ss_sales_price else null end) thu_sales,
+        sum(case when (d_day_name='Friday') then ss_sales_price else null end) fri_sales,
+        sum(case when (d_day_name='Saturday') then ss_sales_price else null end) sat_sales
+into query_59_wss
+ from store_sales,date_dim
+ where d_date_sk = ss_sold_date_sk
+ group by d_week_seq,ss_store_sk;
+
+ -- Generate three tables to speed up query number 78
+ select d_year AS ws_sold_year, ws_item_sk,
+    ws_bill_customer_sk ws_customer_sk,
+    sum(ws_quantity) ws_qty,
+    sum(ws_wholesale_cost) ws_wc,
+    sum(ws_sales_price) ws_sp
+    into query_78_ws
+   from web_sales
+   left join web_returns on wr_order_number=ws_order_number and ws_item_sk=wr_item_sk
+   join date_dim on ws_sold_date_sk = d_date_sk
+   where wr_order_number is null
+   group by d_year, ws_item_sk, ws_bill_customer_sk;
+select d_year AS cs_sold_year, cs_item_sk,
+    cs_bill_customer_sk cs_customer_sk,
+    sum(cs_quantity) cs_qty,
+    sum(cs_wholesale_cost) cs_wc,
+    sum(cs_sales_price) cs_sp
+   into query_78_cs
+   from catalog_sales
+   left join catalog_returns on cr_order_number=cs_order_number and cs_item_sk=cr_item_sk
+   join date_dim on cs_sold_date_sk = d_date_sk
+   where cr_order_number is null
+   group by d_year, cs_item_sk, cs_bill_customer_sk;
+select d_year AS ss_sold_year, ss_item_sk,
+    ss_customer_sk,
+    sum(ss_quantity) ss_qty,
+    sum(ss_wholesale_cost) ss_wc,
+    sum(ss_sales_price) ss_sp
+   into query_78_ss
+   from store_sales
+   left join store_returns on sr_ticket_number=ss_ticket_number and ss_item_sk=sr_item_sk
+   join date_dim on ss_sold_date_sk = d_date_sk
+   where sr_ticket_number is null
+   group by d_year, ss_item_sk, ss_customer_sk;

--- a/useful_tables.sql
+++ b/useful_tables.sql
@@ -1,0 +1,24 @@
+-- Generate a table to speed up query number 2 
+with wscs as
+ (select ws_sold_date_sk sold_date_sk
+              ,ws_ext_sales_price sales_price
+        from web_sales 
+        union all
+        select cs_sold_date_sk sold_date_sk
+              ,cs_ext_sales_price sales_price
+        from catalog_sales),
+ wswscs as 
+ (select d_week_seq,
+        sum(case when (d_day_name='Sunday') then sales_price else null end) sun_sales,
+        sum(case when (d_day_name='Monday') then sales_price else null end) mon_sales,
+        sum(case when (d_day_name='Tuesday') then sales_price else  null end) tue_sales,
+        sum(case when (d_day_name='Wednesday') then sales_price else null end) wed_sales,
+        sum(case when (d_day_name='Thursday') then sales_price else null end) thu_sales,
+        sum(case when (d_day_name='Friday') then sales_price else null end) fri_sales,
+        sum(case when (d_day_name='Saturday') then sales_price else null end) sat_sales
+ from wscs
+     ,date_dim
+ where d_date_sk = sold_date_sk
+ group by d_week_seq)
+ select *
+ into query_2_wswscs from wswscs;

--- a/useful_tables.sql
+++ b/useful_tables.sql
@@ -124,3 +124,18 @@ with year_total as (
          ,c_email_address
          ,d_year
          ) select * into query_6_year_total from year_total;
+
+-- query 31
+with ss as
+ (select ca_county,d_qoy, d_year,sum(ss_ext_sales_price) as store_sales
+ from store_sales,date_dim,customer_address
+ where ss_sold_date_sk = d_date_sk
+  and ss_addr_sk=ca_address_sk
+ group by ca_county,d_qoy, d_year)
+ select * into query_31_ss from ss;
+with ws as
+ (select ca_county,d_qoy, d_year,sum(ws_ext_sales_price) as web_sales
+ from web_sales,date_dim,customer_address
+ where ws_sold_date_sk = d_date_sk
+  and ws_bill_addr_sk=ca_address_sk
+ group by ca_county,d_qoy, d_year) select * into query_31_ws from ws;


### PR DESCRIPTION
This are the fixes we have done to make queries better:

1. `query14.tpl`: there were two queries in this template, both of them making the same CTE. So I created two temporal tables for each one. Then there were catalog_sales , store_sales and web_sales doing an index seed, with a hit for WITH (FORCESCAN) it improved a lot!. At least 200% faster.
2. `query7`: FORCESCAN and replacing cross product with joins
3. `query2`: made a new  table at ETL time. 
4. `query47`: replacing ors with unions
5. `query4`: replacing cross product with joins and delete unnecessary statements
6. `query57`: FORCESCAN and inner join
7. `query59`: added new table at ETL time
8. `query78`: added 3 new  table at ETL time
9. `query11`: adds 1 new  table
10. `query31`: adds 1 new table